### PR TITLE
adding magical research scripts

### DIFF
--- a/check-symbiosis.lic
+++ b/check-symbiosis.lic
@@ -1,0 +1,97 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#check-symbiosis
+=end
+
+custom_require.call(%w[common common-arcana drinfomon spellmonitor])
+
+class SymbiosisCheck
+
+  def initialize
+    arg_definitions = [
+      [
+        {
+          name: 'symbiosis_type',
+          optional: true,
+          options: %w[activate avoid cast discern endure examine explore harness harvest heal impress learn perform remember resolve spell spring strengthen watch],
+          description: "Which symbiosis do you want to check? Argument -> Yaml -> defaults to harness"
+        }
+      ]
+    ]
+    args = DRC.parse_args(arg_definitions)
+
+    symbiosis_type = args.symbiosis_type || get_settings.symbiotic_research_type || 'harness'
+    validate_known_feat_for_symbiosis(symbiosis_type)
+    research_symbiosis(symbiosis_type)
+  end
+
+  def research_symbiosis(new_symbiosis)
+    current_symbiosis = perc_symbiotic_research # DRCA
+
+    # is the correct symbiotic research already up?
+    if current_symbiosis.downcase != new_symbiosis.downcase
+      # wrong symbiotic research is active, release it
+      if current_symbiosis
+        DRC.message("Wrong symbiotic research active, correcting")
+        DRC.message("Releasing: #{current_symbiosis}")
+        release_magical_research # DRCA
+      end
+      DRC.message("Researching: #{new_symbiosis}")
+      DRC.wait_for_script_to_complete('researcher', ['symbiosis', new_symbiosis])
+    else
+      DRC.message("Symbiotic research for '#{new_symbiosis}' is already active")
+    end
+  end
+
+  def validate_known_feat_for_symbiosis(symbiosis_type)
+    feat_type = get_feat_for_symbiosis(symbiosis_type)
+
+    if feat_type.nil?
+      DRC.message("Unknown symbiosis type: #{symbiosis_type}")
+      DRC.message("To add support for this symbiosis, please submit an issue on GitHub:")
+      DRC.message("https://github.com/rpherbig/dr-scripts/issues")
+      exit
+    end
+
+    # check that you have the correct spell feat
+    if !DRSpells.known_feats[feat_type]
+      DRC.message("You don't know the '#{feat_type}' feat for '#{symbiosis_type}' symbiosis")
+      DRC.message("See https://elanthipedia.play.net/Magical_feats for more info")
+      exit
+    end
+  end
+
+  def get_feat_for_symbiosis(symbiosis_type)
+    # different feats needed for different types
+    feat_for_symbioses = {
+      'Symbiotic Research' => ['activate', 'case', 'harness'],
+      'Mental Matrices' => ['discern', 'impress', 'remember', 'resolve'],
+      'Physical Matrices' => ['avoid', 'endure', 'spring', 'strengthen'],
+      'Scholar' => ['examine', 'learn', 'perform'],
+      'Survivalist' => ['explore', 'harvest', 'heal', 'watch']
+    }
+    # which feat is needed?
+    feat_for_symbioses
+      .select { |feat, symbioses| symbioses.include?(symbiosis_type.downcase) }
+      .map { |feat, symbioses| feat }
+      .first
+  end
+
+  # What, if any, symbiotic research is active?
+  # TODO move this method to common-arcana
+  def perc_symbiotic_research
+    case DRC.bput('perceive', /combine the weaves of the (\w+) symbiosis/, /Roundtime/)
+    when /combine the weaves of the (\w+) symbiosis/
+      Regexp.last_match(1)
+    else
+      nil
+    end
+  end
+
+  # TODO move this method to common-arcana
+  def release_magical_research
+    2.times { DRC.bput("release symbiosis", "Are you sure", "You intentionally wipe", "But you haven't") }
+  end
+
+end
+
+SymbiosisCheck.new

--- a/check-symbiosis.lic
+++ b/check-symbiosis.lic
@@ -28,7 +28,10 @@ class SymbiosisCheck
     current_symbiosis = DRCA.perc_symbiotic_research
 
     # is the correct symbiotic research already up?
-    if current_symbiosis.downcase != new_symbiosis.downcase
+    if current_symbiosis.downcase == new_symbiosis.downcase
+        DRC.message("Symbiotic research for '#{new_symbiosis}' is already active")
+        return
+    end
       # wrong symbiotic research is active, release it
       if current_symbiosis
         DRC.message("Wrong symbiotic research active, correcting")

--- a/check-symbiosis.lic
+++ b/check-symbiosis.lic
@@ -25,7 +25,7 @@ class SymbiosisCheck
   end
 
   def research_symbiosis(new_symbiosis)
-    current_symbiosis = perc_symbiotic_research # DRCA
+    current_symbiosis = DRCA.perc_symbiotic_research
 
     # is the correct symbiotic research already up?
     if current_symbiosis.downcase != new_symbiosis.downcase
@@ -33,7 +33,7 @@ class SymbiosisCheck
       if current_symbiosis
         DRC.message("Wrong symbiotic research active, correcting")
         DRC.message("Releasing: #{current_symbiosis}")
-        release_magical_research # DRCA
+        DRCA.release_magical_research
       end
       DRC.message("Researching: #{new_symbiosis}")
       DRC.wait_for_script_to_complete('researcher', ['symbiosis', new_symbiosis])
@@ -75,23 +75,6 @@ class SymbiosisCheck
       .map { |feat, symbioses| feat }
       .first
   end
-
-  # What, if any, symbiotic research is active?
-  # TODO move this method to common-arcana
-  def perc_symbiotic_research
-    case DRC.bput('perceive', /combine the weaves of the (\w+) symbiosis/, /Roundtime/)
-    when /combine the weaves of the (\w+) symbiosis/
-      Regexp.last_match(1)
-    else
-      nil
-    end
-  end
-
-  # TODO move this method to common-arcana
-  def release_magical_research
-    2.times { DRC.bput("release symbiosis", "Are you sure", "You intentionally wipe", "But you haven't") }
-  end
-
 end
 
 SymbiosisCheck.new

--- a/check-symbiosis.lic
+++ b/check-symbiosis.lic
@@ -19,7 +19,7 @@ class SymbiosisCheck
     ]
     args = DRC.parse_args(arg_definitions)
 
-    symbiosis_type = args.symbiosis_type || get_settings.symbiotic_research_type || 'harness'
+    symbiosis_type = args.symbiosis_type || get_settings.symbiotic_research_type
     validate_known_feat_for_symbiosis(symbiosis_type)
     research_symbiosis(symbiosis_type)
   end
@@ -36,7 +36,7 @@ class SymbiosisCheck
         DRCA.release_magical_research
       end
       DRC.message("Researching: #{new_symbiosis}")
-      DRC.wait_for_script_to_complete('researcher', ['symbiosis', new_symbiosis])
+      start_script('researcher', ['symbiosis', new_symbiosis])
     else
       DRC.message("Symbiotic research for '#{new_symbiosis}' is already active")
     end

--- a/check-symbiosis.lic
+++ b/check-symbiosis.lic
@@ -36,7 +36,7 @@ class SymbiosisCheck
         DRCA.release_magical_research
       end
       DRC.message("Researching: #{new_symbiosis}")
-      start_script('researcher', ['symbiosis', new_symbiosis])
+      DRC.wait_for_script_to_complete('researcher', ['symbiosis', new_symbiosis])
     else
       DRC.message("Symbiotic research for '#{new_symbiosis}' is already active")
     end

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -663,6 +663,10 @@ training_nonspells:
 crossing_training:
 use_research: false
 research_skills:
+
+#used to train augment when casting spells with symbiosis
+symbiotic_research_type: harness
+
 water_holder:
 # a metal weapon to light flint with, lighters dont work
 flint_lighter:

--- a/researcher.lic
+++ b/researcher.lic
@@ -1,0 +1,183 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#check-symbiosis
+=end
+begin
+  custom_require.call %[common common-arcana drinfomon events]
+rescue
+  echo "Dependency is not running! This script requires dependency to be installed and running."
+  exit
+end
+
+
+class Researcher
+  include DRC
+
+  def initialize
+    args = get_args
+
+    @settings = get_settings
+    @current_topic = nil
+    add_flags
+    UserVars.researcher ||= {}
+    check_status
+
+    if args.skill || args.symbiosis || args.guild_skill
+      @current_topic = args.skill if args.skill
+      @current_topic = "symbiosis #{args.sym_type}" if args.symbiosis
+      @current_topic = convert_guild_skills(args.guild_skill) if args.guild
+      check_research
+      loop do
+        pause 5
+        check_research
+        break unless researching
+      end
+    else
+      echo "Using YAML settings is not supported at the moment, please specify a research target, or type ';researcher help' for a list of targets"
+      exit
+    end
+  end
+
+  def convert_guild_skills(skill)
+    case skill
+      when 'astro', 'astrology', 'plane'
+        'plane'
+      when 'summon', 'summoning', 'planes'
+        'planes'
+      when 'therugy', 'road'
+        'road'
+    end 
+  end
+
+
+  def set_researching(status)
+    UserVars.researcher['researching'] = status
+    UserVars.researcher['timestamp'] = Time.now
+  end
+
+  def researching
+    return false if Flags['research-partial']
+    return false if Flags['research-complete']
+    return false unless DRSpells.active_spells.include?('Gauge Flow')
+    UserVars.researcher['researching']
+  end
+
+  def add_flags
+    # Use the same flags from crossing-training
+    Flags.add('research-partial', 'there is still more to learn before you arrive at a breakthrough', 'distracted by combat', 'distracted by your spellcasting', 'You lose your focus on your research project', 'you forget what you were') unless Flags['research-partial']
+    Flags.add('research-complete', '^Breakthrough!', 'You complete reviewing your knowledge of the \w+ symbiosis and commit the details to memory') unless Flags['research-complete']
+  end
+
+  def check_status
+    case DRC.bput('research status', 'You estimate that you will complete it a few minutes from now', "You're not researching anything", "You have completed .+ of a project about")
+      when /You estimate that you will complete it a few minutes from now/
+        set_researching(true)
+      when /You're not researching anything/, /You have completed .+ of a project about/
+        set_researching(false)
+    end
+  end
+
+  def check_research
+    if Flags['research-partial']
+      Flags.reset('research-partial')
+      set_researching(false)
+      start_research
+    elsif Flags['research-complete']
+      Flags.reset('research-complete')
+      set_researching(false)
+      @current_topic = nil
+    else
+      start_research
+    end
+  end
+
+  def start_research
+    return if researching
+
+    research_start_msgs = [
+      'You focus', 
+      'You tentatively', 
+      'You confidently', 
+      'Abandoning the normal', 
+      'You are already busy',
+      'You start to research',
+      'With a mixture of rational concern',
+      'You expertly coach',
+      'You begin to bend',
+      'You bring yourself',
+      'Inwardly, you make an exercise',
+      'You orient in the figurative direction'
+    ]
+
+    research_start_fail_msgs = [
+      'You cannot begin',
+      'Usage:', 
+      'You do not know how to research'
+    ]
+
+
+    check_gaf
+    @current_topic = 'stream' if @current_topic == 'attunement'
+    case bput("research #{@current_topic} 300", research_start_msgs, research_start_fail_msgs )
+    when 'You cannot begin'
+      DRCA.release_magical_research
+      start_research
+    when *research_start_msgs
+      set_researching(true)
+    when 'Usage:', 'You do not know how to research'
+      DRC.message("Invalid research option")
+      set_researching(false)
+      exit
+    end
+  end
+
+  def check_gaf
+    return if DRSpells.active_spells.include?('Gauge Flow')
+    # Doing the AND check for set and spell is to not rely on lich nil; indexing into a non-existant key raises exception, not nil.
+    # TODO: try something similar to python dictionary .get method instead
+    if @settings['waggle_sets']['gaf'] && @settings['waggle_sets']['gaf']['Gauge Flow']
+      DRCA.cast_spell(@settings['waggle_sets']['gaf']['Gauge Flow'], @settings)
+    else
+      DRC.message("Using min prep. Make a waggle_set called 'gaf' with Gauge Flow in it if you want more control")
+      DRCA.cast_spell({ 'abbrev' => 'gaf', 'mana' => 5}, @settings)
+    end
+  end
+
+  def get_args
+    arg_definitions = [
+      [
+        { name: 'skill',
+          options: %w[
+            attunement augmentation energy field fundamental
+            sorcery spell stream utility warding
+          ], 
+          description: 'What skill or type of research do you want to do?'}
+      ],
+      [
+        { name: 'symbiosis', regex: /symbiosis/i, description: "Do symbiosis research?"},
+        { name: 'sym_type', options: %w[
+          activate avoid cast discern endure
+          examine explore harness harvest
+          heal impress learn perform remember
+          resolve spell spring strengthen watch
+          ], 
+          description: "Which symbiosis do you want to research?"}
+      ],
+      [
+        { name: 'guild', regex: /guild/i, description: "Perform guild specific research"},
+        {
+          name: 'guild_skill', 
+          options: %w[
+            astrology astro plane
+            summoning summon planes
+            theurgy cleric road
+          ],
+          description: "which guild skill?"
+        }
+      ]
+    ]
+    DRC.parse_args(arg_definitions)
+  end
+
+end
+
+Researcher.new

--- a/researcher.lic
+++ b/researcher.lic
@@ -133,12 +133,10 @@ class Researcher
 
   def check_gaf
     return if DRSpells.active_spells['Gauge Flow'].to_i > 20
-    # Doing the AND check for set and spell is to not rely on lich nil; indexing into a non-existant key raises exception, not nil.
-    # TODO: try something similar to python dictionary .get method instead
-    if @settings['waggle_sets']['gaf'] && @settings['waggle_sets']['gaf']['Gauge Flow']
-      DRCA.cast_spell(@settings['waggle_sets']['gaf']['Gauge Flow'], @settings)
+    if @settings.waggle_sets['researcher']
+      DRC.wait_for_script_to_complete('buff', ['researcher', 'force'])
     else
-      DRC.message("Using min prep. Make a waggle_set called 'gaf' with Gauge Flow in it if you want more control")
+      DRC.message("Using min prep. Make a waggle_set called 'researcher' with Gauge Flow in it if you want more control")
       DRCA.cast_spell({ 'abbrev' => 'gaf', 'mana' => 5}, @settings)
     end
   end

--- a/researcher.lic
+++ b/researcher.lic
@@ -1,11 +1,11 @@
 =begin
-  Documentation: https://elanthipedia.play.net/Lich_script_repository#researcher
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#check-symbiosis
 =end
 
-custom_require.call %[common common-arcana drinfomon events]
+custom_require.call(%w[common common-arcana drinfomon events])
+
 
 class Researcher
-  include DRC
 
   def initialize
     args = get_args

--- a/researcher.lic
+++ b/researcher.lic
@@ -8,7 +8,13 @@ custom_require.call(%w[common common-arcana drinfomon events])
 class Researcher
 
   def initialize
-    args = get_args
+    # define required research arrays 
+    @cleric_research = [ 'theurgy', 'road' ]
+    @warrior_mage_research = [ 'summon', 'summoning', 'planes' ]
+    @moon_mage_research = [ 'plane', 'astro', 'astrology' ]
+    
+
+    args = DRC.parse_args(get_args)
 
     @settings = get_settings
     @current_topic = nil
@@ -20,6 +26,7 @@ class Researcher
       @current_topic = args.skill if args.skill
       @current_topic = "symbiosis #{args.sym_type}" if args.symbiosis
       @current_topic = convert_guild_skills(args.guild_skill) if args.guild
+      @current_topic = 'stream' if @current_topic == 'attunement'
       check_research
       loop do
         pause 5
@@ -27,21 +34,20 @@ class Researcher
         break unless researching
       end
     else
-    unless args.skill || args.symbiosis || args.guild_skill
-      echo "Using YAML settings is not supported at the moment, please specify a research target, or type ';researcher help' for a list of targets"
-      exit
-  end
-      exit
+      unless args.skill || args.symbiosis || args.guild_skill
+        echo "Using YAML settings is not supported at the moment, please specify a research target, or type ';researcher help' for a list of targets"
+        exit
+      end
     end
   end
 
   def convert_guild_skills(skill)
     case skill
-      when 'astro', 'astrology', 'plane'
+      when *@moon_mage_research
         'plane'
-      when 'summon', 'summoning', 'planes'
+      when *@warrior_mage_research
         'planes'
-      when 'theurgy', 'road'
+      when *@cleric_research
         'road'
     end 
   end
@@ -114,8 +120,7 @@ class Researcher
 
 
     check_gaf
-    @current_topic = 'stream' if @current_topic == 'attunement'
-    case bput("research #{@current_topic} 300", research_start_msgs, research_start_fail_msgs )
+    case DRC.bput("research #{@current_topic} 300", research_start_msgs, research_start_fail_msgs )
     when 'You cannot begin'
       DRCA.release_magical_research
       start_research
@@ -164,18 +169,12 @@ class Researcher
         { name: 'guild', regex: /guild/i, description: "Perform guild specific research"},
         {
           name: 'guild_skill', 
-          options: %w[
-            astrology astro plane
-            summoning summon planes
-            theurgy road
-          ],
+          options: [ @moon_mage_research, @warrior_mage_research, @cleric_research ] ,
           description: "which guild skill?"
         }
       ]
     ]
-    DRC.parse_args(arg_definitions)
   end
-
 end
 
 Researcher.new

--- a/researcher.lic
+++ b/researcher.lic
@@ -118,23 +118,23 @@ class Researcher
       'You do not know how to research'
     ]
 
-
     check_gaf
+
     case DRC.bput("research #{@current_topic} 300", research_start_msgs, research_start_fail_msgs )
-    when 'You cannot begin'
-      DRCA.release_magical_research
-      start_research
-    when *research_start_msgs
-      set_researching(true)
-    when 'Usage:', 'You do not know how to research'
-      DRC.message("Invalid research option")
-      set_researching(false)
-      exit
+      when 'You cannot begin'
+        DRCA.release_magical_research
+        start_research
+      when *research_start_msgs
+        set_researching(true)
+      when 'Usage:', 'You do not know how to research'
+        DRC.message("Invalid research option")
+        set_researching(false)
+        exit
     end
   end
 
   def check_gaf
-    return if DRSpells.active_spells.include?('Gauge Flow')
+    return if DRSpells.active_spells.include?('Gauge Flow') && DRSpells.active_spells['Gauge Flow'].to_i > 20
     # Doing the AND check for set and spell is to not rely on lich nil; indexing into a non-existant key raises exception, not nil.
     # TODO: try something similar to python dictionary .get method instead
     if @settings['waggle_sets']['gaf'] && @settings['waggle_sets']['gaf']['Gauge Flow']

--- a/researcher.lic
+++ b/researcher.lic
@@ -1,5 +1,5 @@
 =begin
-  Documentation: https://elanthipedia.play.net/Lich_script_repository#check-symbiosis
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#researcher
 =end
 
 custom_require.call(%w[common common-arcana drinfomon events])

--- a/researcher.lic
+++ b/researcher.lic
@@ -164,7 +164,7 @@ class Researcher
           options: %w[
             astrology astro plane
             summoning summon planes
-            theurgy cleric road
+            theurgy road
           ],
           description: "which guild skill?"
         }

--- a/researcher.lic
+++ b/researcher.lic
@@ -1,13 +1,8 @@
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#researcher
 =end
-begin
-  custom_require.call %[common common-arcana drinfomon events]
-rescue
-  echo "Dependency is not running! This script requires dependency to be installed and running."
-  exit
-end
 
+custom_require.call %[common common-arcana drinfomon events]
 
 class Researcher
   include DRC

--- a/researcher.lic
+++ b/researcher.lic
@@ -38,7 +38,7 @@ class Researcher
         'plane'
       when 'summon', 'summoning', 'planes'
         'planes'
-      when 'therugy', 'road'
+      when 'theurgy', 'road'
         'road'
     end 
   end

--- a/researcher.lic
+++ b/researcher.lic
@@ -52,7 +52,6 @@ class Researcher
     end 
   end
 
-
   def set_researching(status)
     UserVars.researcher['researching'] = status
     UserVars.researcher['timestamp'] = Time.now

--- a/researcher.lic
+++ b/researcher.lic
@@ -13,7 +13,6 @@ class Researcher
     @warrior_mage_research = [ 'summon', 'summoning', 'planes' ]
     @moon_mage_research = [ 'plane', 'astro', 'astrology' ]
     
-
     args = DRC.parse_args(get_args)
 
     @settings = get_settings

--- a/researcher.lic
+++ b/researcher.lic
@@ -27,7 +27,10 @@ class Researcher
         break unless researching
       end
     else
+    unless args.skill || args.symbiosis || args.guild_skill
       echo "Using YAML settings is not supported at the moment, please specify a research target, or type ';researcher help' for a list of targets"
+      exit
+  end
       exit
     end
   end

--- a/researcher.lic
+++ b/researcher.lic
@@ -1,5 +1,5 @@
 =begin
-  Documentation: https://elanthipedia.play.net/Lich_script_repository#check-symbiosis
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#researcher
 =end
 begin
   custom_require.call %[common common-arcana drinfomon events]

--- a/researcher.lic
+++ b/researcher.lic
@@ -133,7 +133,7 @@ class Researcher
   end
 
   def check_gaf
-    return if DRSpells.active_spells.include?('Gauge Flow') && DRSpells.active_spells['Gauge Flow'].to_i > 20
+    return if DRSpells.active_spells['Gauge Flow'].to_i > 20
     # Doing the AND check for set and spell is to not rely on lich nil; indexing into a non-existant key raises exception, not nil.
     # TODO: try something similar to python dictionary .get method instead
     if @settings['waggle_sets']['gaf'] && @settings['waggle_sets']['gaf']['Gauge Flow']


### PR DESCRIPTION
Relies on updates to common-arcana https://github.com/rpherbig/dr-scripts/pull/5511

Thanks to Crannach the original creator of researcher.lic on the in-game repo
Modified to add in all missing research options for normal and symbiotic research. Also added in guild specific research.

check-symbiosis.lic relies on research.lic and will make sure your symbiotic research is both active and the one you want.